### PR TITLE
Fix the revenue ternary operator

### DIFF
--- a/mParticle-Localytics.podspec
+++ b/mParticle-Localytics.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
     s.name             = "mParticle-Localytics"
-    s.version          = "6.0.6"
+    s.version          = "6.0.7"
     s.summary          = "Localytics integration for mParticle"
 
     s.description      = <<-DESC

--- a/mParticle-Localytics/MPKitLocalytics.m
+++ b/mParticle-Localytics/MPKitLocalytics.m
@@ -141,7 +141,7 @@
             NSDictionary *commerceEventAttributes = [commerceEvent beautifiedAttributes];
             NSString *eventName = [NSString stringWithFormat:@"eCommerce - %@", [[commerceEvent actionNameForAction:commerceEvent.action] capitalizedString]];
             long revenue = lround([commerceEvent.transactionAttributes.revenue doubleValue] * (multiplyByOneHundred ? 100 : 1));
-            revenue = commerceEvent.action == MPCommerceEventActionPurchase ? : labs(revenue) * -1;
+            revenue = commerceEvent.action == MPCommerceEventActionPurchase ? revenue : labs(revenue) * -1;
 
             [Localytics tagEvent:eventName attributes:commerceEventAttributes customerValueIncrease:@(revenue)];
             [execStatus incrementForwardCount];


### PR DESCRIPTION
The revenue ternary operator was always setting revenue to 1, rather than evaluate the condition and assign the left or right value
