### PR TITLE
fix: Header imports for mParticle SDK

### DIFF
--- a/mParticle-Localytics.podspec
+++ b/mParticle-Localytics.podspec
@@ -22,8 +22,7 @@ Pod::Spec.new do |s|
 
     s.ios.pod_target_xcconfig = {
         'LIBRARY_SEARCH_PATHS' => '$(inherited) $(PODS_ROOT)/Localytics/**',
-        'FRAMEWORK_SEARCH_PATHS' => '$(inherited) $(PODS_ROOT)/Localytics/**',
-        'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64'
+        'FRAMEWORK_SEARCH_PATHS' => '$(inherited) $(PODS_ROOT)/Localytics/**'
     }
     s.ios.user_target_xcconfig = { 'OTHER_LDFLAGS' => '$(inherited) -framework "CoreLocation"', 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64' }
 
@@ -34,8 +33,7 @@ Pod::Spec.new do |s|
 
     s.tvos.pod_target_xcconfig = {
         'LIBRARY_SEARCH_PATHS' => '$(inherited) $(PODS_ROOT)/Localytics/**',
-        'FRAMEWORK_SEARCH_PATHS' => '$(inherited) $(PODS_ROOT)/Localytics/**',
-        'EXCLUDED_ARCHS[sdk=appletvsimulator*]' => 'arm64'
+        'FRAMEWORK_SEARCH_PATHS' => '$(inherited) $(PODS_ROOT)/Localytics/**'
     }
     s.tvos.user_target_xcconfig = { 'OTHER_LDFLAGS' => '$(inherited) -framework "CoreLocation"', 'EXCLUDED_ARCHS[sdk=appletvsimulator*]' => 'arm64' }
 

--- a/mParticle-Localytics.podspec
+++ b/mParticle-Localytics.podspec
@@ -24,7 +24,7 @@ Pod::Spec.new do |s|
         'LIBRARY_SEARCH_PATHS' => '$(inherited) $(PODS_ROOT)/Localytics/**',
         'FRAMEWORK_SEARCH_PATHS' => '$(inherited) $(PODS_ROOT)/Localytics/**'
     }
-    s.ios.user_target_xcconfig = { 'OTHER_LDFLAGS' => '$(inherited) -framework "CoreLocation"', 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64' }
+    s.ios.user_target_xcconfig = { 'OTHER_LDFLAGS' => '$(inherited) -framework "CoreLocation"' }
 
     s.tvos.deployment_target = "9.0"
     s.tvos.source_files      = 'mParticle-Localytics/*.{h,m,mm}'
@@ -35,6 +35,6 @@ Pod::Spec.new do |s|
         'LIBRARY_SEARCH_PATHS' => '$(inherited) $(PODS_ROOT)/Localytics/**',
         'FRAMEWORK_SEARCH_PATHS' => '$(inherited) $(PODS_ROOT)/Localytics/**'
     }
-    s.tvos.user_target_xcconfig = { 'OTHER_LDFLAGS' => '$(inherited) -framework "CoreLocation"', 'EXCLUDED_ARCHS[sdk=appletvsimulator*]' => 'arm64' }
+    s.tvos.user_target_xcconfig = { 'OTHER_LDFLAGS' => '$(inherited) -framework "CoreLocation"' }
 
 end

--- a/mParticle-Localytics/MPKitLocalytics.h
+++ b/mParticle-Localytics/MPKitLocalytics.h
@@ -1,8 +1,13 @@
 #import <Foundation/Foundation.h>
 #if defined(__has_include) && __has_include(<mParticle_Apple_SDK/mParticle.h>)
-#import <mParticle_Apple_SDK/mParticle.h>
+    #import <mParticle_Apple_SDK/mParticle.h>
+    #import <mParticle_Apple_SDK/mParticle_Apple_SDK-Swift.h>
+#elif defined(__has_include) && __has_include(<mParticle_Apple_SDK_NoLocation/mParticle.h>)
+    #import <mParticle_Apple_SDK_NoLocation/mParticle.h>
+    #import <mParticle_Apple_SDK_NoLocation/mParticle_Apple_SDK-Swift.h>
 #else
-#import "mParticle.h"
+    #import "mParticle.h"
+    #import "mParticle_Apple_SDK-Swift.h"
 #endif
 
 


### PR DESCRIPTION
## Summary
Adds headers for accessing public Swift classes in the core SDK. Marked as fix so semantic release will make a patch version bump instead of minor version bump.

## Testing Instructions
Tested by compiling and running a local app to see that there were no header or Swift related errors.
